### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/SyedMohd/223f0c3c-8ecd-4472-baf7-2ae1babe0f45/35158c6c-4005-43ea-b383-c69e3ff0057e/_apis/work/boardbadge/db3f7f07-bd7b-4bbb-8ed1-d6adb77a11e8)](https://dev.azure.com/SyedMohd/223f0c3c-8ecd-4472-baf7-2ae1babe0f45/_boards/board/t/35158c6c-4005-43ea-b383-c69e3ff0057e/Microsoft.RequirementCategory)
 #######
 ### Prerequisites
 - JDK 1.8 or later


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/SyedMohd/223f0c3c-8ecd-4472-baf7-2ae1babe0f45/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.